### PR TITLE
Check for multiple FlowPlater loads

### DIFF
--- a/double-loading-test.html
+++ b/double-loading-test.html
@@ -49,7 +49,8 @@
             <li>FlowPlater is loaded once in the first script tag below</li>
             <li>Click "Load FlowPlater Again" to simulate loading it a second time</li>
             <li>Check the console output to see the protection warning</li>
-            <li>Verify that the original FlowPlater instance is preserved</li>
+            <li>Verify that the original FlowPlater instance is preserved (early return prevents new instance creation)</li>
+            <li>Note: HTMX and Handlebars globals are still updated even on duplicate loads</li>
         </ol>
     </div>
 

--- a/double-loading-test.html
+++ b/double-loading-test.html
@@ -50,7 +50,6 @@
             <li>Click "Load FlowPlater Again" to simulate loading it a second time</li>
             <li>Check the console output to see the protection warning</li>
             <li>Verify that the original FlowPlater instance is preserved (early return prevents new instance creation)</li>
-            <li>Note: HTMX and Handlebars globals are still updated even on duplicate loads</li>
         </ol>
     </div>
 

--- a/double-loading-test.html
+++ b/double-loading-test.html
@@ -1,0 +1,185 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>FlowPlater Double Loading Protection Test</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            max-width: 800px;
+            margin: 0 auto;
+            padding: 20px;
+        }
+        .test-section {
+            border: 1px solid #ccc;
+            padding: 20px;
+            margin: 10px 0;
+            border-radius: 5px;
+        }
+        .console-output {
+            background: #f5f5f5;
+            padding: 15px;
+            margin: 10px 0;
+            border-radius: 5px;
+            font-family: monospace;
+            white-space: pre-wrap;
+        }
+        button {
+            padding: 10px 20px;
+            margin: 5px;
+            border: none;
+            border-radius: 3px;
+            background: #007bff;
+            color: white;
+            cursor: pointer;
+        }
+        button:hover {
+            background: #0056b3;
+        }
+    </style>
+</head>
+<body>
+    <h1>FlowPlater Double Loading Protection Test</h1>
+    
+    <div class="test-section">
+        <h3>Test Instructions</h3>
+        <p>This test demonstrates FlowPlater's protection against double loading:</p>
+        <ol>
+            <li>FlowPlater is loaded once in the first script tag below</li>
+            <li>Click "Load FlowPlater Again" to simulate loading it a second time</li>
+            <li>Check the console output to see the protection warning</li>
+            <li>Verify that the original FlowPlater instance is preserved</li>
+        </ol>
+    </div>
+
+    <div class="test-section">
+        <h3>Test Controls</h3>
+        <button onclick="loadFlowPlaterAgain()">Load FlowPlater Again</button>
+        <button onclick="checkFlowPlaterState()">Check FlowPlater State</button>
+        <button onclick="clearConsole()">Clear Console Output</button>
+        
+        <h4>Console Output:</h4>
+        <div id="consoleOutput" class="console-output">
+            Test initialized. Click buttons to test double loading protection.
+        </div>
+    </div>
+
+    <div class="test-section">
+        <h3>FlowPlater Test Element</h3>
+        <div fp-instance="test-instance" fp-template="test-template">
+            Loading...
+        </div>
+        
+        <template id="test-template">
+            <div>
+                <h4>FlowPlater Instance: {{instanceName}}</h4>
+                <p>Load Time: {{loadTime}}</p>
+                <p>Test Data: {{testValue}}</p>
+            </div>
+        </template>
+    </div>
+
+    <!-- First FlowPlater load -->
+    <script src="dist/flowplater.js"></script>
+    
+    <script>
+        // Capture console.warn to display in our test output
+        const originalWarn = console.warn;
+        const originalLog = console.log;
+        const consoleOutput = document.getElementById('consoleOutput');
+        
+        function logToOutput(message, type = 'log') {
+            const timestamp = new Date().toLocaleTimeString();
+            const output = `[${timestamp}] ${type.toUpperCase()}: ${message}\n`;
+            consoleOutput.textContent += output;
+            consoleOutput.scrollTop = consoleOutput.scrollHeight;
+        }
+        
+        console.warn = function(...args) {
+            originalWarn.apply(console, args);
+            logToOutput(args.join(' '), 'warn');
+        };
+        
+        console.log = function(...args) {
+            originalLog.apply(console, args);
+            logToOutput(args.join(' '), 'log');
+        };
+        
+        // Initialize test data
+        let originalFlowPlater = null;
+        let loadCount = 0;
+        
+        document.addEventListener('DOMContentLoaded', function() {
+            if (window.FlowPlater) {
+                originalFlowPlater = window.FlowPlater;
+                loadCount++;
+                
+                // Set up test instance
+                const instance = FlowPlater.getInstance('test-instance');
+                if (instance) {
+                    instance.setData({
+                        instanceName: 'test-instance',
+                        loadTime: new Date().toLocaleString(),
+                        testValue: 'Initial load #' + loadCount
+                    });
+                }
+                
+                logToOutput('FlowPlater loaded successfully (Load #' + loadCount + ')');
+                logToOutput('FlowPlater VERSION: ' + FlowPlater.VERSION);
+            } else {
+                logToOutput('ERROR: FlowPlater not found!', 'error');
+            }
+        });
+        
+        function loadFlowPlaterAgain() {
+            logToOutput('Attempting to load FlowPlater again...');
+            
+            // Simulate loading FlowPlater script again
+            const script = document.createElement('script');
+            script.src = 'dist/flowplater.js?' + Date.now(); // Add timestamp to bypass cache
+            script.onload = function() {
+                loadCount++;
+                logToOutput('Script loaded (Load #' + loadCount + ')');
+                
+                // Check if it's the same instance
+                if (window.FlowPlater === originalFlowPlater) {
+                    logToOutput('SUCCESS: Same FlowPlater instance preserved!', 'success');
+                } else {
+                    logToOutput('ERROR: FlowPlater instance was replaced!', 'error');
+                    originalFlowPlater = window.FlowPlater;
+                }
+                
+                checkFlowPlaterState();
+            };
+            script.onerror = function() {
+                logToOutput('ERROR: Failed to load FlowPlater script', 'error');
+            };
+            
+            document.head.appendChild(script);
+        }
+        
+        function checkFlowPlaterState() {
+            if (window.FlowPlater) {
+                logToOutput('FlowPlater VERSION: ' + window.FlowPlater.VERSION);
+                logToOutput('FlowPlater instances: ' + Object.keys(window.FlowPlater.getInstances()).length);
+                logToOutput('FlowPlater instance names: ' + Object.keys(window.FlowPlater.getInstances()).join(', '));
+                
+                // Check if our test instance still exists
+                const instance = window.FlowPlater.getInstance('test-instance');
+                if (instance) {
+                    logToOutput('Test instance still exists with data: ' + JSON.stringify(instance.data));
+                } else {
+                    logToOutput('ERROR: Test instance was lost!', 'error');
+                }
+            } else {
+                logToOutput('ERROR: FlowPlater not found!', 'error');
+            }
+        }
+        
+        function clearConsole() {
+            consoleOutput.textContent = 'Console cleared.\n';
+        }
+    </script>
+</body>
+</html>

--- a/flowplater-double-loading-analysis.md
+++ b/flowplater-double-loading-analysis.md
@@ -1,0 +1,197 @@
+# FlowPlater Double Loading Analysis
+
+## Current Behavior When FlowPlater is Loaded Twice
+
+Based on the codebase analysis, here's what happens when FlowPlater is loaded twice:
+
+### 1. **Partial Protection in `init()` Method**
+
+FlowPlater has some protection against double initialization in the `init()` method:
+
+```typescript
+// From FlowPlater.ts lines 388-396
+if (_state.initialized) {
+  if (element !== document) {
+    Performance.start("init-element");
+    Debug.info("Re-initializing FlowPlater for element:", element);
+    process(element);
+    Performance.end("init-element");
+  } else {
+    Debug.debug("FlowPlater already initialized, skipping document re-initialization");
+  }
+  return this;
+}
+```
+
+**What this protects:**
+- Prevents full re-initialization of the document when `FlowPlater.init()` is called again
+- Allows re-initialization of specific elements
+- Maintains the existing state and instances
+
+### 2. **Global Window Object Replacement**
+
+However, there's a critical issue with script loading:
+
+```typescript
+// From FlowPlater.ts lines 820-822
+if (typeof window !== 'undefined') {
+  (window as unknown as FlowPlaterWindow).FlowPlater = FlowPlaterObj;
+}
+```
+
+**What happens:**
+- Each script load completely replaces `window.FlowPlater` with a new instance
+- The new instance has a fresh `_state` object
+- All previous instances, groups, and configuration are lost
+
+### 3. **Auto-Initialization on Each Load**
+
+```typescript
+// From FlowPlater.ts lines 838-842
+if (document.readyState === "complete" || document.readyState === "interactive") {
+  FlowPlaterObj.init();
+} else {
+  document.addEventListener("DOMContentLoaded", () => FlowPlaterObj.init());
+}
+```
+
+**What happens:**
+- Each script load attempts auto-initialization
+- The second load creates a new FlowPlaterObj and calls init() again
+- Due to the init() protection, it may skip re-initialization, but the state is already lost
+
+## Potential Issues
+
+### 1. **State Loss**
+- **Instances**: All previously created instances are lost
+- **Groups**: All group data is reset
+- **Configuration**: Custom configuration is lost
+- **Plugin State**: Plugin data and state are reset
+- **Template Cache**: Compiled templates are lost
+
+### 2. **Memory Leaks**
+- Previous event listeners may not be cleaned up
+- Old DOM references may persist
+- Plugin cleanup may not occur properly
+
+### 3. **Inconsistent Behavior**
+- Elements processed by the first load may not work with the second instance
+- HTMX extensions may be registered multiple times
+- Event handlers may be duplicated
+
+### 4. **Plugin Issues**
+- Plugins registered with the first instance are lost
+- Global methods added by plugins are overwritten
+- Plugin state is not preserved
+
+## Code Evidence
+
+### State Management
+```typescript
+// From State.ts - Fresh state on each load
+export const _state = {
+  templateCache: {} as Record<string, any>,
+  instances: {} as Record<string, FlowPlaterInstance>,
+  groups: {} as Record<string, FlowPlaterGroup>,
+  length: 0,
+  initialized: false,
+  // ...
+};
+```
+
+### Plugin Registration
+```typescript
+// From PluginManager.ts - Global methods are overwritten
+if (window.FlowPlater) {
+  window.FlowPlater[methodName] = (...args: any[]) =>
+    this.executeGlobalMethod(methodName, ...args);
+}
+```
+
+## Recommended Solutions
+
+### 1. **Global Loading Protection**
+Add a global flag to prevent multiple script loads:
+
+```typescript
+// At the top of FlowPlater.ts
+if (typeof window !== 'undefined' && window.FlowPlater && window.FlowPlater.VERSION) {
+  console.warn('FlowPlater is already loaded. Skipping duplicate load.');
+  // Export the existing instance instead of creating a new one
+  export default window.FlowPlater;
+  // Stop execution here
+}
+```
+
+### 2. **State Preservation**
+If double loading is detected, preserve the existing state:
+
+```typescript
+// Before replacing window.FlowPlater
+if (typeof window !== 'undefined' && window.FlowPlater) {
+  const existingState = {
+    instances: window.FlowPlater.getInstances(),
+    groups: window.FlowPlater.getGroups(),
+    config: window.FlowPlater.getConfig(),
+    plugins: window.FlowPlater.getAllPlugins()
+  };
+  
+  // Restore state after creating new instance
+  Object.assign(_state.instances, existingState.instances);
+  Object.assign(_state.groups, existingState.groups);
+  ConfigManager.setConfig(existingState.config);
+  // Re-register plugins...
+}
+```
+
+### 3. **Cleanup on Replacement**
+Properly clean up the previous instance:
+
+```typescript
+if (typeof window !== 'undefined' && window.FlowPlater && window.FlowPlater.destroy) {
+  console.warn('Cleaning up previous FlowPlater instance');
+  window.FlowPlater.destroy();
+}
+```
+
+### 4. **Version Checking**
+Add version compatibility checking:
+
+```typescript
+if (typeof window !== 'undefined' && window.FlowPlater) {
+  const existingVersion = window.FlowPlater.VERSION;
+  if (existingVersion !== VERSION) {
+    console.warn(`FlowPlater version mismatch: ${existingVersion} -> ${VERSION}`);
+    // Handle version conflicts
+  }
+}
+```
+
+## Current Risk Assessment
+
+**High Risk Issues:**
+- Complete state loss on double loading
+- Potential memory leaks from unclean replacement
+- Plugin functionality loss
+- Inconsistent behavior in complex applications
+
+**Medium Risk Issues:**
+- Performance impact from re-processing elements
+- Debugging difficulties due to state loss
+- HTMX extension conflicts
+
+**Low Risk Issues:**
+- Console warnings/errors
+- Minor performance overhead
+
+## Conclusion
+
+FlowPlater currently has **insufficient protection** against double loading. While the `init()` method has some safeguards, the global object replacement causes complete state loss, which can lead to serious issues in production applications.
+
+The recommended approach is to implement comprehensive loading protection that:
+1. Detects existing FlowPlater instances
+2. Preserves state when possible
+3. Provides clear warnings about conflicts
+4. Handles version mismatches gracefully
+
+This would prevent the silent failures and state loss that currently occur with double loading.

--- a/src/core/FlowPlater.ts
+++ b/src/core/FlowPlater.ts
@@ -52,15 +52,6 @@ import "../types";
 if (typeof window !== 'undefined' && window.FlowPlater && window.FlowPlater.VERSION) {
   console.warn('FlowPlater is already loaded. Skipping duplicate load to prevent state loss and conflicts.');
   
-  // Still set up HTMX and Handlebars globals in case they weren't set by the first load
-  if (typeof window.htmx === 'undefined') {
-    window.htmx = htmxLib;
-  }
-  if (typeof window.Handlebars === 'undefined') {
-    window.Handlebars = Handlebars;
-    registerHelpers();
-  }
-  
   // Early return - stops all further execution (works in compiled IIFE)
   // @ts-ignore - TypeScript doesn't know this will be in a function context after compilation
   return window.FlowPlater;


### PR DESCRIPTION
Add protection against duplicate FlowPlater loading to prevent state loss and conflicts.

Previously, loading FlowPlater multiple times would silently replace `window.FlowPlater` with a new instance. This caused complete loss of application state (instances, groups, configuration, plugin state, template cache), potential memory leaks, and inconsistent behavior. This PR implements an early return check at the script's entry point to ensure only the first load initializes FlowPlater, preserving the original instance and preventing these critical issues.